### PR TITLE
Make sort-imports fix the sort order

### DIFF
--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -41,6 +41,8 @@ const getFirstLocalMemberName = node =>
   node.specifiers[0] ? node.specifiers[0].local.name : null
 
 const checkSpecifiers = ( context, node, ignoreMemberSort, ignoreCase ) => {
+  const soureCode = context.getSourceCode();
+
   if ( !ignoreMemberSort && node.specifiers.length > 1 ) {
     let pSpecifier
     let pSpecifierName
@@ -68,6 +70,14 @@ const checkSpecifiers = ( context, node, ignoreMemberSort, ignoreCase ) => {
           data: {
             memberName: cSpecifier.local.name,
           },
+          fix(fixer) {
+            return fixer.replaceTextRange(
+              [
+                pSpecifier.range[0],
+                cSpecifier.range[1],
+              ],
+              `${sourceCode.getText(cSpecifier)}, ${sourceCode.getText(pSpecifier)}`
+            );
         })
       }
 

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -79,6 +79,7 @@ const checkSpecifiers = ( context, node, ignoreMemberSort, ignoreCase ) => {
 
 module.exports = {
   meta: {
+    fixable: 'code',
     schema: [
       {
         type: 'object',
@@ -133,6 +134,18 @@ module.exports = {
             cLocalMemberName = lower(cLocalMemberName)
           }
 
+          function fixAlpha( fixer ) {
+            const sourceCode = context.getSourceCode();
+
+            return fixer.replaceTextRange(
+                [
+                    pNode.range[0],
+                    node.range[1],
+                ],
+                `${sourceCode.getText(node)}\n${sourceCode.getText(pNode)}`
+            );
+          }
+
           // When the current declaration uses a different member syntax,
           // then check if the ordering is correct.
           // Otherwise, make a default string compare (like rule sort-vars
@@ -147,6 +160,7 @@ module.exports = {
                   syntaxA: memberSyntaxSortOrder[cMemberSyntaxGroupIndex],
                   syntaxB: memberSyntaxSortOrder[pMemberSyntaxGroupIndex],
                 },
+                fix: fixAlpha,
               })
             }
           } else if (
@@ -157,6 +171,7 @@ module.exports = {
             context.report({
               node,
               message: 'Imports should be sorted alphabetically.',
+              fix: fixAlpha,
             })
           }
         }


### PR DESCRIPTION
Known issue: eslint will only run one fix at a time and it will only try to fix a node 10 times. That means if a node is off by more than 10, you will have to run eslint more than once.