### PR TITLE
Use original delimiter when fixing specifiers

### DIFF
--- a/lib/rules/__tests__/sort-imports.test.js
+++ b/lib/rules/__tests__/sort-imports.test.js
@@ -11,8 +11,35 @@ const expectedError = {
   message: 'Imports should be sorted alphabetically.',
   type: 'ImportDeclaration',
 }
+const beforeError = ( a, b ) => `Expected '${a}' syntax before '${b}' syntax.`
 const ignoreCaseArgs = [ { ignoreCase: true } ]
 const ignoreMemberSortArgs = [ { ignoreMemberSort: true } ]
+
+const imports = {
+  all: "import * as a from 'a'",
+  default: "import b from 'b'",
+  named: "import { c } from 'c'",
+  none: "import 'd'",
+  type: "import type { E } from 'e'",
+}
+
+const makeMemberSyntaxSortOrderTest = ( memberSyntaxSortOrder, a, b ) => ({
+  code:
+  `
+  ${imports[b]}
+  ${imports[a]}
+  `,
+  errors: [ beforeError(a, b) ],
+  options: [
+    { memberSyntaxSortOrder },
+  ],
+  output:
+  `
+  ${imports[a]}
+  ${imports[b]}
+  `,
+  parser,
+})
 
 new RuleTester({ parserOptions }).run('sort-imports', rule, {
   valid: [
@@ -358,16 +385,14 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       code:
       `
       import * as foo from 'foo.js'
-      import * as baz from 'baz.js'
-      import * as bar from 'bar.js'
       import * as Foo from 'Foo.js'
       `,
-      errors: 3,
+      errors: [
+        expectedError,
+      ],
       output:
       `
       import * as Foo from 'Foo.js'
-      import * as bar from 'bar.js'
-      import * as baz from 'baz.js'
       import * as foo from 'foo.js'
       `,
     },
@@ -377,34 +402,28 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       `
       import a from 'foo.js'
       import A from 'bar.js'
-      import b from 'foobar.js'
-      import C from 'baz.js'
       `,
-      errors: 2,
+      errors: [
+        expectedError,
+      ],
       output:
       `
       import A from 'bar.js'
-      import C from 'baz.js'
       import a from 'foo.js'
-      import b from 'foobar.js'
       `,
     },
     // named syntax
     {
       code:
       `
-      import { b, c } from 'foo.js'
       import { a, b } from 'bar.js'
-      import { b, C } from 'foobar.js'
       import { A, b, D, e } from 'baz.js'
       `,
-      errors: 4,
+      errors: 2,
       output:
       `
-      import { A, D, b, e } from 'baz.js'
-      import { C, b } from 'foobar.js'
+      import { A, b, D, e } from 'baz.js'
       import { a, b } from 'bar.js'
-      import { b, c } from 'foo.js'
       `,
     },
     // none syntax
@@ -413,14 +432,36 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       `
       import a from 'foo.js'
       import 'bar.js'
-      import { b, c } from 'foobar.js'
-      import 'baz.js'
       `,
-      errors: 2,
+      errors: 1,
       output:
       `
       import 'bar.js'
-      import 'baz.js'
+      import a from 'foo.js'
+      `,
+    },
+    {
+      code:
+      `
+      import { b, c } from 'foobar.js'
+      import 'bar.js'
+      `,
+      errors: 1,
+      output:
+      `
+      import 'bar.js'
+      import { b, c } from 'foobar.js'
+      `,
+    },
+    {
+      code:
+      `
+      import a from 'foo.js'
+      import { b, c } from 'foobar.js'
+      `,
+      errors: 1,
+      output:
+      `
       import { b, c } from 'foobar.js'
       import a from 'foo.js'
       `,
@@ -429,18 +470,14 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
     {
       code:
       `
-      import B from 'b'
       import type { C } from 'c'
       import 'd'
-      import type { A } from 'a'
       `,
-      errors: 2,
+      errors: 1,
       output:
       `
       import 'd'
-      import type { A } from 'a'
       import type { C } from 'c'
-      import B from 'b'
       `,
       parser,
     },
@@ -474,29 +511,47 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       import { a, B, c, D } from 'a'
       `,
     },
+  ].concat(
     // memberSyntaxSortOrder: [ 'type', 'all', 'none', 'default', 'named' ]
-    {
-      code:
-      `
-      import { e } from 'e'
-      import a from 'a'
-      import 'c'
-      import type { D } from 'd'
-      import * as b from 'b'
-      `,
-      errors: 3,
-      options: [
-        { memberSyntaxSortOrder: [ 'type', 'all', 'none', 'default', 'named' ] },
-      ],
-      output:
-      `
-      import type { D } from 'd'
-      import * as b from 'b'
-      import 'c'
-      import a from 'a'
-      import { e } from 'e'
-      `,
-      parser,
-    },
-  ],
+    makeMemberSyntaxSortOrderTest(
+      [ 'type', 'all', 'none', 'default', 'named' ],
+      'default', 'named'
+    ),
+    makeMemberSyntaxSortOrderTest(
+      [ 'type', 'all', 'none', 'default', 'named' ],
+      'none', 'default'
+    ),
+    makeMemberSyntaxSortOrderTest(
+      [ 'type', 'all', 'none', 'default', 'named' ],
+      'none', 'named'
+    ),
+    makeMemberSyntaxSortOrderTest(
+      [ 'type', 'all', 'none', 'default', 'named' ],
+      'all', 'none'
+    ),
+    makeMemberSyntaxSortOrderTest(
+      [ 'type', 'all', 'none', 'default', 'named' ],
+      'all', 'default'
+    ),
+    makeMemberSyntaxSortOrderTest(
+      [ 'type', 'all', 'none', 'default', 'named' ],
+      'all', 'named'
+    ),
+    makeMemberSyntaxSortOrderTest(
+      [ 'type', 'all', 'none', 'default', 'named' ],
+      'type', 'all'
+    ),
+    makeMemberSyntaxSortOrderTest(
+      [ 'type', 'all', 'none', 'default', 'named' ],
+      'type', 'none'
+    ),
+    makeMemberSyntaxSortOrderTest(
+      [ 'type', 'all', 'none', 'default', 'named' ],
+      'type', 'default'
+    ),
+    makeMemberSyntaxSortOrderTest(
+      [ 'type', 'all', 'none', 'default', 'named' ],
+      'type', 'named'
+    )
+  ),
 })

--- a/lib/rules/__tests__/sort-imports.test.js
+++ b/lib/rules/__tests__/sort-imports.test.js
@@ -149,6 +149,26 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       import A from 'bar.js'
       `,
       errors: [ expectedError ],
+      output:
+      `
+      import A from 'bar.js'
+      import a from 'foo.js'
+      `,
+    },
+    {
+      code:
+      `
+      import a from 'foo.js'
+
+      import A from 'bar.js'
+      `,
+      errors: [ expectedError ],
+      output:
+      `
+      import A from 'bar.js'
+
+      import a from 'foo.js'
+      `,
     },
     {
       code:
@@ -157,12 +177,22 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       import a from 'bar.js'
       `,
       errors: [ expectedError ],
+      output:
+      `
+      import a from 'bar.js'
+      import b from 'foo.js'
+      `,
     },
     {
       code:
       `
       import { b, c } from 'foo.js'
       import { a, b } from 'bar.js'
+      `,
+      output:
+      `
+      import { a, b } from 'bar.js'
+      import { b, c } from 'foo.js'
       `,
       errors: [ expectedError ],
     },
@@ -172,6 +202,11 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       import * as foo from 'foo.js'
       import * as bar from 'bar.js'
       `,
+      output:
+      `
+      import * as bar from 'bar.js'
+      import * as foo from 'foo.js'
+      `,
       errors: [ expectedError ],
     },
     {
@@ -179,6 +214,11 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       `
       import a from 'foo.js'
       import { b, c } from 'bar.js'
+      `,
+      output:
+      `
+      import { b, c } from 'bar.js'
+      import a from 'foo.js'
       `,
       errors: [
         {
@@ -193,6 +233,11 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       import a from 'foo.js'
       import * as b from 'bar.js'
       `,
+      output:
+      `
+      import * as b from 'bar.js'
+      import a from 'foo.js'
+      `,
       errors: [
         {
           message: "Expected 'all' syntax before 'default' syntax.",
@@ -206,6 +251,11 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       import a from 'foo.js'
       import 'bar.js'
       `,
+      output:
+      `
+      import 'bar.js'
+      import a from 'foo.js'
+      `,
       errors: [
         {
           message: "Expected 'none' syntax before 'default' syntax.",
@@ -218,6 +268,11 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       `
       import b from 'bar.js'
       import * as a from 'foo.js'
+      `,
+      output:
+      `
+      import * as a from 'foo.js'
+      import b from 'bar.js'
       `,
       options: [
         {
@@ -238,6 +293,10 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       `
       import { b, a, d, c } from 'foo.js'
       `,
+      output:
+      `
+      import { a, b, c, d } from 'foo.js'
+      `,
       errors: [
         {
           message: "Member 'a' of the import declaration should be sorted" +
@@ -255,6 +314,10 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       code:
       `
       import { a, B, c, D } from 'foo.js'
+      `,
+      output:
+      `
+      import { B, a, D, c } from 'foo.js'
       `,
       errors: [
         {
@@ -274,6 +337,11 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       `
       import B from 'b'
       import type { C } from 'c'
+      `,
+      output:
+      `
+      import type { C } from 'c'
+      import B from 'b'
       `,
       parser,
       errors: [

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -1,3 +1,5 @@
+/* eslint-disable wyze/max-file-length */
+
 'use strict'
 
 const enums = [ 'none', 'type', 'all', 'named', 'default' ]
@@ -40,18 +42,64 @@ const usedMemberSyntax = node => {
 const getFirstLocalMemberName = node =>
   node.specifiers[0] ? node.specifiers[0].local.name : null
 
+const getRootNode = node => {
+  let testNode = node
+
+  while ( testNode ) {
+    if ( testNode.type === 'Program' ) {
+      return testNode
+    }
+    testNode = testNode.parent
+  }
+
+  throw new Error('Could not get Program node')
+}
+
+const getContentBetweenSpecifiers = ( context, parent, nodeOrTokenA, nodeOrTokenB ) => {
+  const sourceCode = context.getSourceCode()
+  const text = sourceCode.getText(parent)
+
+  const start = nodeOrTokenA.end - parent.start
+  const length = nodeOrTokenB.start - nodeOrTokenA.end
+  const contentBetween = text.substr(start, length)
+
+  return contentBetween
+}
+
+
+const getContentBetweenDeclarations = ( context, nodeOrTokenA, nodeOrTokenB ) => {
+  const sourceCode = context.getSourceCode()
+  const rootNode = getRootNode(nodeOrTokenA)
+
+  const text = sourceCode.getText(rootNode)
+
+  const start = nodeOrTokenA.end - nodeOrTokenA.start
+  const length = nodeOrTokenB.start - nodeOrTokenA.end
+  const contentBetween = text.substr(start, length)
+
+  return contentBetween
+}
+
 const checkSpecifiers = ( context, getText, node, ignoreMemberSort, ignoreCase ) => {
   if ( !ignoreMemberSort && node.specifiers.length > 1 ) {
     let pSpecifier
     let pSpecifierName
-    const makeFix = cSpecifier => fixer =>
-      fixer.replaceTextRange(
+    const makeFix = cSpecifier => fixer => {
+      const delimiter = getContentBetweenSpecifiers(
+        context,
+        node,
+        pSpecifier.local,
+        cSpecifier.local
+      )
+
+      return fixer.replaceTextRange(
         [
           pSpecifier.range[0],
           cSpecifier.range[1],
         ],
-        `${getText(cSpecifier)}, ${getText(pSpecifier)}`
+        `${getText(cSpecifier)}${delimiter}${getText(pSpecifier)}`
       )
+    }
 
     // eslint-disable-next-line no-plusplus
     for ( let i = 0; i < node.specifiers.length; ++i ) {
@@ -149,14 +197,18 @@ module.exports = {
             cLocalMemberName = lower(cLocalMemberName)
           }
 
-          const fix = fixer =>
-            fixer.replaceTextRange(
+          const fix = fixer => {
+            const delimiter = getContentBetweenDeclarations(context, pNode, node)
+
+
+            return fixer.replaceTextRange(
               [
                 pNode.range[0],
                 node.range[1],
               ],
-              `${getText(node)}\n${getText(pNode)}`
+              `${getText(node)}${delimiter}${getText(pNode)}`
             )
+          }
 
           // When the current declaration uses a different member syntax,
           // then check if the ordering is correct.


### PR DESCRIPTION
Before, we would always separate specifiers with a space, even if it was originally delimited by a line break.