### PR TITLE
Fixed tests failing due to repeated variable names in mock code

### DIFF
--- a/lib/rules/__tests__/func-params-spacing.test.js
+++ b/lib/rules/__tests__/func-params-spacing.test.js
@@ -181,19 +181,19 @@ new RuleTester({ parserOptions }).run('func-params-spacing', rule, {
       code:
       `
       const a = b.reduce(( c, d) => c + d, 0)
-      const a = b.reduce((c, d ) => c + d, 0)
-      const a = b.reduce((c, d) => c + d, 0)
-      const a = b.reduce(( ) => Math.random(5), 0)
-      const a = b.reduce(function (c, d) { c + d }, 0)
+      const b = b.reduce((c, d ) => c + d, 0)
+      const c = b.reduce((c, d) => c + d, 0)
+      const d = b.reduce(( ) => Math.random(5), 0)
+      const e = b.reduce(function (c, d) { c + d }, 0)
       `,
       errors: 7,
       output:
       `
       const a = b.reduce(( c, d ) => c + d, 0)
-      const a = b.reduce(( c, d ) => c + d, 0)
-      const a = b.reduce(( c, d ) => c + d, 0)
-      const a = b.reduce(() => Math.random(5), 0)
-      const a = b.reduce(function ( c, d ) { c + d }, 0)
+      const b = b.reduce(( c, d ) => c + d, 0)
+      const c = b.reduce(( c, d ) => c + d, 0)
+      const d = b.reduce(() => Math.random(5), 0)
+      const e = b.reduce(function ( c, d ) { c + d }, 0)
       `,
     },
     {
@@ -243,52 +243,52 @@ new RuleTester({ parserOptions }).run('func-params-spacing', rule, {
       code:
       `
       const foo = ({ a } ) => {}
-      const foo = ( { a } ) => {}
-      const foo = ( { a }) => {}
-      const foo = ({ a }, b ) => {}
-      const foo = ( { a }, b) => {}
-      const foo = ( { a }, b, [ c ] ) => {}
-      const foo = ( { a }, b, [ c ]) => {}
-      const foo = ({ a }, b, [ c ] ) => {}
+      const foo2 = ( { a } ) => {}
+      const foo3 = ( { a }) => {}
+      const foo4 = ({ a }, b ) => {}
+      const foo5 = ( { a }, b) => {}
+      const foo6 = ( { a }, b, [ c ] ) => {}
+      const foo7 = ( { a }, b, [ c ]) => {}
+      const foo8 = ({ a }, b, [ c ] ) => {}
       `,
       errors: 10,
       output:
       `
       const foo = ({ a }) => {}
-      const foo = ({ a }) => {}
-      const foo = ({ a }) => {}
-      const foo = ( { a }, b ) => {}
-      const foo = ( { a }, b ) => {}
-      const foo = ({ a }, b, [ c ]) => {}
-      const foo = ({ a }, b, [ c ]) => {}
-      const foo = ({ a }, b, [ c ]) => {}
+      const foo2 = ({ a }) => {}
+      const foo3 = ({ a }) => {}
+      const foo4 = ( { a }, b ) => {}
+      const foo5 = ( { a }, b ) => {}
+      const foo6 = ({ a }, b, [ c ]) => {}
+      const foo7 = ({ a }, b, [ c ]) => {}
+      const foo8 = ({ a }, b, [ c ]) => {}
       `,
     },
     {
       code:
       `
       const foo = (a: string ) => {}
-      const foo = (a: string) => {}
-      const foo = ( a: string) => {}
-      const foo = ({ a }: { a: string } ): void => {}
-      const foo = ( { a }: { a: string } ): void => {}
-      const foo = ( { a }: { a: string }): void => {}
-      const foo = ({ a }: Object ): void => {}
-      const foo = ( { a }: Object): void => {}
-      const foo = ({ a }: Object): void => {}
+      const foo2 = (a: string) => {}
+      const foo3 = ( a: string) => {}
+      const foo4 = ({ a }: { a: string } ): void => {}
+      const foo5 = ( { a }: { a: string } ): void => {}
+      const foo6 = ( { a }: { a: string }): void => {}
+      const foo7 = ({ a }: Object ): void => {}
+      const foo8 = ( { a }: Object): void => {}
+      const foo9 = ({ a }: Object): void => {}
       `,
       errors: 12,
       output:
       `
       const foo = ( a: string ) => {}
-      const foo = ( a: string ) => {}
-      const foo = ( a: string ) => {}
-      const foo = ({ a }: { a: string }): void => {}
-      const foo = ({ a }: { a: string }): void => {}
-      const foo = ({ a }: { a: string }): void => {}
-      const foo = ( { a }: Object ): void => {}
-      const foo = ( { a }: Object ): void => {}
-      const foo = ( { a }: Object ): void => {}
+      const foo2 = ( a: string ) => {}
+      const foo3 = ( a: string ) => {}
+      const foo4 = ({ a }: { a: string }): void => {}
+      const foo5 = ({ a }: { a: string }): void => {}
+      const foo6 = ({ a }: { a: string }): void => {}
+      const foo7 = ( { a }: Object ): void => {}
+      const foo8 = ( { a }: Object ): void => {}
+      const foo9 = ( { a }: Object ): void => {}
       `,
       parser,
     },
@@ -313,25 +313,25 @@ new RuleTester({ parserOptions }).run('func-params-spacing', rule, {
       code:
       `
       const foo = function(a, b, c) {}
-      const foo = function( a, b, c) {}
-      const foo = function(a, b, c ) {}
-      const foo = ( a, b, c) => {}
-      const foo = (a, b, c ) => {}
-      const foo = (a, b, c) => {}
-      const foo = ( ) => {}
-      const foo = function( ) {}
+      const foo2 = function( a, b, c) {}
+      const foo3 = function(a, b, c ) {}
+      const foo4 = ( a, b, c) => {}
+      const foo5 = (a, b, c ) => {}
+      const foo6 = (a, b, c) => {}
+      const foo7 = ( ) => {}
+      const foo8 = function( ) {}
       `,
       errors: 10,
       output:
       `
       const foo = function( a, b, c ) {}
-      const foo = function( a, b, c ) {}
-      const foo = function( a, b, c ) {}
-      const foo = ( a, b, c ) => {}
-      const foo = ( a, b, c ) => {}
-      const foo = ( a, b, c ) => {}
-      const foo = () => {}
-      const foo = function() {}
+      const foo2 = function( a, b, c ) {}
+      const foo3 = function( a, b, c ) {}
+      const foo4 = ( a, b, c ) => {}
+      const foo5 = ( a, b, c ) => {}
+      const foo6 = ( a, b, c ) => {}
+      const foo7 = () => {}
+      const foo8 = function() {}
       `,
     },
     {
@@ -340,10 +340,10 @@ new RuleTester({ parserOptions }).run('func-params-spacing', rule, {
       const foo = ( {
         a
       } ) => {}
-      const foo = ({
+      const foo2 = ({
         a
       } ) => {}
-      const foo = ( {
+      const foo3 = ( {
         a
       }) => {}
       `,
@@ -353,10 +353,10 @@ new RuleTester({ parserOptions }).run('func-params-spacing', rule, {
       const foo = ({
         a
       }) => {}
-      const foo = ({
+      const foo2 = ({
         a
       }) => {}
-      const foo = ({
+      const foo3 = ({
         a
       }) => {}
       `,

--- a/lib/rules/__tests__/sort-imports.test.js
+++ b/lib/rules/__tests__/sort-imports.test.js
@@ -76,7 +76,7 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
     },
     `
     import { a, b } from 'bar.js'
-    import { b, c } from 'foo.js'
+    import { c, d } from 'foo.js'
     `,
     `
     import A from 'foo.js'
@@ -88,7 +88,7 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
     `,
     `
     import a, * as b from 'foo.js'
-    import b from 'bar.js'
+    import c from 'bar.js'
     `,
     `
     import 'foo.js'
@@ -214,11 +214,11 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       code:
       `
       import { b, c } from 'foo.js'
-      import { a, b } from 'bar.js'
+      import { a, d } from 'bar.js'
       `,
       output:
       `
-      import { a, b } from 'bar.js'
+      import { a, d } from 'bar.js'
       import { b, c } from 'foo.js'
       `,
       errors: [ expectedError ],
@@ -417,12 +417,12 @@ new RuleTester({ parserOptions }).run('sort-imports', rule, {
       code:
       `
       import { a, b } from 'bar.js'
-      import { A, b, D, e } from 'baz.js'
+      import { A, c, D, e } from 'baz.js'
       `,
       errors: 2,
       output:
       `
-      import { A, b, D, e } from 'baz.js'
+      import { A, c, D, e } from 'baz.js'
       import { a, b } from 'bar.js'
       `,
     },


### PR DESCRIPTION
Re-opening the PR from https://github.com/wyze/eslint-plugin-wyze/pull/14 with only the fixes to failing tests.

Tests were failing due to the linter throwing errors for repeated identifiers used and the test not accounting for them in the expected errors.

I made all identifiers in mock code unique so that only the expected errors would appear.